### PR TITLE
Smooth out bikes by adding visual interpolation

### DIFF
--- a/client/src/network/bike.rs
+++ b/client/src/network/bike.rs
@@ -1,0 +1,34 @@
+//! Module to handle the networking of bikes on the client side
+
+use avian2d::prelude::{Position, RigidBody, Rotation};
+use bevy::prelude::*;
+use lightyear::prelude::client::*;
+use shared::player::bike::BikeMarker;
+
+pub struct BikeNetworkPlugin;
+
+
+impl Plugin for BikeNetworkPlugin {
+    fn build(&self, app: &mut App) {
+        // run this after the Predicted bike gets spawned and has its components synced,
+        app.add_systems(PreUpdate, handle_new_predicted_bike.after(PredictionSet::SpawnHistory));
+    }
+}
+
+/// When a predicted bike gets created, we want to:
+/// - add VisualInterpolateStatus component to visually interpolate the bike's Position/Rotation in Update
+/// between two FixedUpdate values
+/// - add RigidBody::Kinematic component so that the bike is affected by physics
+fn handle_new_predicted_bike(
+    mut commands: Commands,
+    predicted_bikes: Query<Entity, (With<BikeMarker>, With<Predicted>, Without<VisualInterpolateStatus<Position>>)>,
+) {
+    for entity in predicted_bikes.iter() {
+        commands.entity(entity)
+            .insert((
+                    VisualInterpolateStatus::<Position>::default(),
+                    VisualInterpolateStatus::<Rotation>::default(),
+                    RigidBody::Kinematic
+            ));
+    }
+}

--- a/client/src/network/mod.rs
+++ b/client/src/network/mod.rs
@@ -6,6 +6,7 @@ use lightyear::prelude::client::*;
 use shared::network::config::Transports;
 
 pub(crate) mod config;
+mod bike;
 
 /// Plugin that handles networking
 pub(crate) struct NetworkPlugin {
@@ -26,8 +27,8 @@ impl Plugin for NetworkPlugin {
         ));
 
         app.add_plugins(shared::network::protocol::ProtocolPlugin);
-        // app.add_plugins(NetworkInputsPlugin);
-        // app.add_plugins(InterpolationPlugin);
+
+        app.add_plugins(bike::BikeNetworkPlugin);
 
         // TODO: make this state-scoped
         app.add_systems(Startup, connect);

--- a/client/src/render/mod.rs
+++ b/client/src/render/mod.rs
@@ -1,4 +1,4 @@
-use avian2d::prelude::Position;
+use avian2d::prelude::{Position, Rotation};
 use bevy::app::{App, Plugin};
 use lightyear::prelude::client::*;
 
@@ -11,6 +11,7 @@ impl Plugin for RenderPlugin {
         // add visual interpolation to Position, so that position in Update is interpolated
         // between two FixedUpdate values
         app.add_plugins(VisualInterpolationPlugin::<Position>::default());
+        app.add_plugins(VisualInterpolationPlugin::<Rotation>::default());
         app.add_plugins(player::PlayerRenderPlugin);
     }
 }

--- a/shared/src/debug/mod.rs
+++ b/shared/src/debug/mod.rs
@@ -10,14 +10,38 @@ pub struct DebugPlugin;
 
 impl Plugin for DebugPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(Last, last_log);
+        // app.add_systems(FixedPostUpdate, post_fixed_update_log);
+        // app.add_systems(Last, last_log);
+
         if app.is_plugin_added::<RenderPlugin>() {
             app.add_plugins(WorldInspectorPlugin::default());
         }
     }
 }
 
+pub(crate) fn post_fixed_update_log(
+    time: Res<TimeManager>,
+    tick_manager: Res<TickManager>,
+    players: Query<
+        (
+            Entity,
+            &Position,
+            Option<&VisualInterpolateStatus<Position>>,
+            // &Rotation,
+            // Option<&Correction<Position>>,
+            // Option<&Correction<Rotation>>,
+        ),
+        (With<BikeMarker>, Without<Confirmed>, Without<Interpolated>),
+    >,
+) {
+    let tick = tick_manager.tick();
+    for (entity, position, visual_position) in players.iter() {
+        info!(?tick, ?position, ?visual_position, overstep = ?time.overstep(), "Player in POST FIXED UPDATE");
+    }
+}
+
 pub(crate) fn last_log(
+    time: Res<TimeManager>,
     tick_manager: Res<TickManager>,
     players: Query<
         (
@@ -32,6 +56,7 @@ pub(crate) fn last_log(
 ) {
     let tick = tick_manager.tick();
     for (entity, position, rotation) in players.iter() {
+        info!(?tick, ?position, overstep = ?time.overstep(), "Player in LAST");
         trace!(?tick, ?entity, ?position, rotation = ?rotation.as_degrees(), "Player in LAST");
     }
 }

--- a/shared/src/network/protocol.rs
+++ b/shared/src/network/protocol.rs
@@ -29,20 +29,19 @@ impl Plugin for ProtocolPlugin {
             .add_prediction(ComponentSyncMode::Once)
             .add_interpolation(ComponentSyncMode::Once);
 
-        app.register_component::<RigidBody>(ChannelDirection::ServerToClient)
-            .add_prediction(ComponentSyncMode::Once);
-
         app.register_component::<Position>(ChannelDirection::Bidirectional)
             .add_prediction(ComponentSyncMode::Full)
             .add_interpolation(ComponentSyncMode::Full)
-            .add_interpolation_fn(position::lerp)
-            .add_correction_fn(position::lerp);
+            .add_interpolation_fn(position::lerp);
+            // TODO: remove correction for now to make rollbacks more obvious
+            // .add_correction_fn(position::lerp);
 
         app.register_component::<Rotation>(ChannelDirection::Bidirectional)
             .add_prediction(ComponentSyncMode::Full)
             .add_interpolation(ComponentSyncMode::Full)
-            .add_interpolation_fn(rotation::lerp)
-            .add_correction_fn(rotation::lerp);
+            .add_interpolation_fn(rotation::lerp);
+            // TODO: remove correction for now to make rollbacks more obvious
+            // .add_correction_fn(rotation::lerp);
 
         // NOTE: interpolation/correction is only needed for components that are visually displayed!
         // we still need prediction to be able to correctly predict the physics on the client


### PR DESCRIPTION
The predicted bike is updated in FixedUpdate, so we need to smooth the visuals every frame (in PostUpdate).
This should remove any jitter remaining