### PR TITLE
Add delta compression for zones

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ tracing = "0.1"
 tracing-subscriber = "0.3.17"
 bevy = { version = "0.14"}
 clap = { version = "4.5", features = ["derive"] }
+tokio = "=1.38.1"
 
 # Idiomatic Bevy code often triggers these lints, and the CI workflow treats them as errors.
 # In some cases they may still signal poor code quality however, so consider commenting out these lines.

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -36,6 +36,7 @@ bevy.workspace = true
 bevy_turborand.workspace = true
 lightyear.workspace = true
 clap.workspace = true
+tokio.workspace = true
 leafwing-input-manager.workspace = true
 bevy_prototype_lyon = "0.12.0"
 bevy_screen_diagnostics = "0.6"

--- a/client/src/network/bike.rs
+++ b/client/src/network/bike.rs
@@ -23,8 +23,7 @@ impl Plugin for BikeNetworkPlugin {
             PreUpdate,
             handle_new_predicted_bike.after(PredictionSet::SpawnHistory),
         );
-        app.add_systems(PreUpdate, handle_new_confirmed_bike.after(MainSet::Receive));
-        app.add_systems(PreUpdate, handle_new_trail.after(MainSet::Receive));
+        app.add_systems(PreUpdate, (handle_new_trail, handle_new_zones).after(MainSet::Receive));
     }
 }
 
@@ -72,38 +71,36 @@ fn handle_new_trail(
     }
 }
 
-/// When a confirmed bike gets created, we want to:
-/// - create a new entity that will hold the zone mesh to render
-fn handle_new_confirmed_bike(
+/// When a zones entity is replicated, add the render-related components
+fn handle_new_zones(
     mut commands: Commands,
-    // checking with Added<BikeMarker> ensures that we only run this system once for each new bike, including other people's bikes and "mock bikes" for testing
-    confirmed_bikes: Query<(Entity, &BikeMarker, &ColorComponent, &Zones), Added<BikeMarker>>,
+    bikes: Query<(&BikeMarker, &ColorComponent), With<BikeMarker>>,
+    new_zones: Query<(&Parent, Entity), (With<Zones>, Without<ZoneRenderMarker>)>,
 ) {
-    for (entity, bike, color, zones) in confirmed_bikes.iter() {
-        info!("Decorating bike with color: {:?}", color.0);
-
-        // color values above 1.0 enable bloom
-        let c = color.0.to_linear();
-        let zone_fill_color: Color = Color::srgba(c.red, c.green, c.blue, 0.15);
-        let zone_border_color: Color = (c * 2.0).into();
-        let zone_z_order = -(bike.client_id as f32) * 100.0;
-
-        commands.entity(entity).with_children(|parent| {
+    for (parent, entity) in new_zones.iter() {
+        if let Ok((bike, color)) = bikes.get(parent.get()) {
+            // color values above 1.0 enable bloom
+            let c = color.0.to_linear();
+            let zone_fill_color: Color = Color::srgba(c.red, c.green, c.blue, 0.15);
+            let zone_border_color: Color = (c * 2.0).into();
+            let zone_z_order = -(bike.client_id as f32) * 100.0;
             // add the entity that will hold the zone mesh
-            parent
-                .spawn((
+            commands.entity(entity)
+                .insert((
                     ShapeBundle::default(),
                     ZoneRenderMarker,
                     NoFrustumCulling,
                     Fill::color(zone_fill_color),
                     Stroke::new(zone_border_color, 4.0),
+
                 ))
-                .insert(GlobalTransform::from_translation(Vec3::new(
-                    0.0,
-                    0.0,
-                    -zone_z_order,
-                )))
-                .insert(Path::from(zones));
-        });
+                .insert(
+                    GlobalTransform::from_translation(Vec3::new(
+                        0.0,
+                        0.0,
+                        -zone_z_order,
+                    )),
+                );
+        }
     }
 }

--- a/client/src/network/bike.rs
+++ b/client/src/network/bike.rs
@@ -83,7 +83,7 @@ fn handle_new_zones(
             let c = color.0.to_linear();
             let zone_fill_color: Color = Color::srgba(c.red, c.green, c.blue, 0.15);
             let zone_border_color: Color = (c * 2.0).into();
-            let zone_z_order = -(bike.client_id as f32) * 100.0;
+            let zone_z_order = -(bike.client_id.to_bits() as f32) * 100.0;
             // add the entity that will hold the zone mesh
             commands.entity(entity)
                 .insert((

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -35,5 +35,6 @@ avian2d.workspace = true
 bevy.workspace = true
 lightyear.workspace = true
 clap.workspace = true
+tokio.workspace = true
 
 async-compat = "0.2.4"

--- a/server/src/network/connections.rs
+++ b/server/src/network/connections.rs
@@ -4,9 +4,11 @@ use bevy::color::palettes::css;
 use bevy::prelude::*;
 use lightyear::prelude::server::*;
 use lightyear::prelude::*;
-use shared::player::bike::BikeBundle;
+use shared::player::bike::{BikeBundle, BikeMarker};
 use shared::player::trail::{Trail, TrailBundle};
 use shared::player::zone::{Zones, ZonesBundle};
+
+
 
 /// Spawn a new bike when a player connects, along with a `Trail` and a `Zones` entities
 pub(crate) fn spawn_bike(trigger: Trigger<ConnectEvent>, mut commands: Commands) {
@@ -15,6 +17,35 @@ pub(crate) fn spawn_bike(trigger: Trigger<ConnectEvent>, mut commands: Commands)
     let color = color_from_client_id(client_id.to_bits());
     let pos =  Vec2::new(0.0, 0.0);
 
+    // TODO: THIS ONLY WORKS IF BIKE ENTITY IS REPLICATED BEFORE TRAIL/ZONE!!
+    //  THIS MIGHT NOT BE THE CASE IF THEY ARRIVE IN DIFFERENT PACKETS!
+    //  WHAT SHOULD WE DO? SEND MESSAGES?
+
+    // NOTE: for complicated reasons related to lightyear:
+    //  - each entity must be replicated in a different replication group (so that delta compression works)
+    //  - but the trail/zones must be replicated before the bike, so that the BikeMarker has a pointer to the correct entities
+    //  - but the trail/zones must be replicated after the bike, so that the ParentSync has a pointer to the correct entities
+    let bike = commands.spawn((
+        BikeBundle::new_at(client_id, pos, color),
+        RigidBody::Kinematic,
+        Replicate {
+            sync: SyncTarget {
+                prediction: NetworkTarget::Single(client_id),
+                interpolation: NetworkTarget::AllExceptSingle(client_id),
+            },
+            // TODO: add network relevance
+            controlled_by: ControlledBy {
+                target: NetworkTarget::Single(client_id),
+                ..default()
+            },
+            // do not automatically replicate the hierarchy, because we want the trail and the bike
+            // to be part of different ReplicationGroups. This is for delta-compression to work correctly.
+            hierarchy: ReplicateHierarchy {
+                recursive: false,
+            },
+            ..default()
+        },
+    )).id();
     let trail = commands.spawn((
         TrailBundle::new_at(pos),
         // To replicate the parent/child hierarchy
@@ -45,32 +76,16 @@ pub(crate) fn spawn_bike(trigger: Trigger<ConnectEvent>, mut commands: Commands)
             ..default()
         },
     )).id();
-    let mut bike = commands.spawn((
-        BikeBundle::new_at(client_id.to_bits(), pos, color, trail, zones),
-        RigidBody::Kinematic,
-        Replicate {
-            sync: SyncTarget {
-                prediction: NetworkTarget::Single(client_id),
-                interpolation: NetworkTarget::AllExceptSingle(client_id),
-            },
-            // TODO: add network relevance
-            controlled_by: ControlledBy {
-                target: NetworkTarget::Single(client_id),
-                ..default()
-            },
-            // do not automatically replicate the hierarchy, because we want the trail and the bike
-            // to be part of different ReplicationGroups. This is for delta-compression to work correctly.
-            hierarchy: ReplicateHierarchy {
-                recursive: false,
-            },
-            ..default()
-        },
-    ));
-    // NOTE: for complicated reasons related to lightyear:
-    //  - each entity must be replicated in a different replication group (so that delta compression works)
-    //  - but the trail/zones must be replicated before the bike, so that the BikeMarker has a pointer to the correct entities
-    bike.add_child(trail);
-    bike.add_child(zones);
+    commands
+        .entity(bike)
+        .insert(BikeMarker {
+            client_id,
+            stopped: false,
+            trail,
+            zones,
+        })
+        .add_child(trail)
+        .add_child(zones);
 }
 
 pub fn color_from_client_id(client_id: u64) -> Color {

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -16,6 +16,7 @@ lightyear.workspace = true
 clap.workspace = true
 serde.workspace = true
 flo_curves.workspace = true
+tokio.workspace = true
 bevy-inspector-egui = { version = "0.25.1", optional = true }
 bevy_prototype_lyon = "0.12.0"
 geo-types = "0.7.13"

--- a/shared/src/debug/mod.rs
+++ b/shared/src/debug/mod.rs
@@ -7,6 +7,7 @@ use bevy_inspector_egui::quick::WorldInspectorPlugin;
 use lightyear::prelude::client::*;
 use lightyear::prelude::*;
 use lightyear::shared::replication::delta::{DeltaComponentHistory, DeltaManager};
+use crate::player::zone::Zones;
 
 pub struct DebugPlugin;
 
@@ -16,6 +17,7 @@ impl Plugin for DebugPlugin {
         // app.add_systems(Last, last_bike_log);
         // app.add_systems(FixedUpdate, fixed_update_trail_log);
         // app.add_systems(FixedUpdate, delta_manager_log);
+        // app.add_systems(FixedUpdate, log_parent_sync);
 
         if app.is_plugin_added::<RenderPlugin>() {
             app.add_plugins(WorldInspectorPlugin::default());
@@ -26,6 +28,19 @@ impl Plugin for DebugPlugin {
 fn delta_manager_log(manager: Option<Res<ServerConnectionManager>>) {
     if let Some(manager) = manager {
         //info!(?manager.delta_manager, "Delta Manager");
+    }
+}
+
+/// Log entities that have parent sync
+pub(crate) fn log_parent_sync(
+    children: Query<(Entity, &Parent, &ParentSync, Has<Zones>, Has<Trail>)>,
+    bikes: Query<(Entity, &Children, &BikeMarker)>,
+) {
+    for (entity, parent, parent_sync, zone, trail) in children.iter() {
+        info!(?entity, ?parent, ?parent_sync, ?zone, ?trail, "Parent Sync");
+    }
+    for (entity, children, bike) in bikes.iter() {
+        info!(?entity, ?children, ?bike, "Bike");
     }
 }
 

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -28,8 +28,9 @@ impl Plugin for SharedPlugin {
                 StatesPlugin,
                 LogPlugin {
                     level: Level::INFO,
-                    filter: "wgpu=error,bevy_render=info,bevy_ecs=warn,lightyear::client::prediction::rollback=debug".to_string(),
-                    // filter: "wgpu=error,bevy_render=info,bevy_ecs=warn,lightyear::shared::replication::send=info,lightyear::protocol::component=info".to_string(),
+                    // filter: "wgpu=error,bevy_render=info,bevy_ecs=warn".to_string(),
+                    // filter: "wgpu=error,bevy_render=info,bevy_ecs=warn,lightyear::client::prediction::rollback=debug".to_string(),
+                    filter: "wgpu=error,bevy_render=info,bevy_ecs=warn,lightyear::shared::replication::send=warn,lightyear::shared::replication::delta=warn,lightyear::protocol::component=info".to_string(),
                     ..default()
                 },
             ));
@@ -38,8 +39,9 @@ impl Plugin for SharedPlugin {
                 DefaultPlugins
                     .set(LogPlugin {
                         level: Level::INFO,
-                        filter: "wgpu=error,bevy_render=info,bevy_ecs=warn,lightyear::client::prediction::rollback=debug".to_string(),
-                        // filter: "wgpu=error,bevy_render=info,bevy_ecs=warn,lightyear::shared::replication::send=info,lightyear::protocol::component=info".to_string(),
+                        // filter: "wgpu=error,bevy_render=info,bevy_ecs=warn".to_string(),
+                        // filter: "wgpu=error,bevy_render=info,bevy_ecs=warn,lightyear::client::prediction::rollback=debug".to_string(),
+                        filter: "wgpu=error,bevy_render=info,bevy_ecs=warn,lightyear::shared::replication::send=warn,lightyear::shared::replication::delta=warn,lightyear::protocol::component=info".to_string(),
                         ..default()
                     })
                     .set(AssetPlugin {

--- a/shared/src/network/message.rs
+++ b/shared/src/network/message.rs
@@ -1,0 +1,10 @@
+use bevy::prelude::{Component, Entity, Reflect};
+use lightyear::prelude::{Deserialize, Serialize};
+
+/// Message sent to the client to notify that we are spawning an entity
+#[derive(Reflect, Component, Serialize, Deserialize, PartialEq, Debug, Clone)]
+pub struct SpawnPlayerMessage {
+    bike: Entity,
+    trail: Entity,
+    zones: Entity,
+}

--- a/shared/src/network/mod.rs
+++ b/shared/src/network/mod.rs
@@ -1,3 +1,4 @@
 pub mod config;
 pub mod protocol;
 pub mod inputs;
+mod message;

--- a/shared/src/network/protocol.rs
+++ b/shared/src/network/protocol.rs
@@ -34,6 +34,7 @@ impl Plugin for ProtocolPlugin {
             .add_interpolation(ComponentSyncMode::Once);
 
         app.register_component::<BikeMarker>(ChannelDirection::ServerToClient)
+            .add_map_entities()
             .add_prediction(ComponentSyncMode::Once)
             .add_interpolation(ComponentSyncMode::Once);
 
@@ -62,7 +63,8 @@ impl Plugin for ProtocolPlugin {
 
         app.register_component::<Trail>(ChannelDirection::ServerToClient)
             .add_delta_compression();
-        app.register_component::<Zones>(ChannelDirection::ServerToClient);
+        app.register_component::<Zones>(ChannelDirection::ServerToClient)
+            .add_delta_compression();
 
         // channels
         app.add_channel::<Channel1>(ChannelSettings {

--- a/shared/src/physics/movement.rs
+++ b/shared/src/physics/movement.rs
@@ -40,6 +40,7 @@ fn move_bike_system(
     fixed_time: Res<Time<Fixed>>,
     mut query: Query<
         (
+            // TODO: do we need this?
             &mut BikeMarker,
             &mut Position,
             &mut Rotation,
@@ -113,7 +114,7 @@ fn move_bike_system(
                 let scale = ((position.0.x.powi(2) / a.powi(2))
                     + (position.0.y.powi(2) / b.powi(2)))
                 .sqrt();
-                position.0 = Vec2::new((position.0.x / scale), (position.0.y / scale));
+                position.0 = Vec2::new(position.0.x / scale, position.0.y / scale);
 
                 // calculate normal and tangent
                 let normal =

--- a/shared/src/player/bike.rs
+++ b/shared/src/player/bike.rs
@@ -4,7 +4,6 @@ use avian2d::math::Vector;
 use avian2d::prelude::*;
 use bevy::ecs::entity::MapEntities;
 use bevy::prelude::*;
-use lightyear::connection::netcode::ClientId;
 use lightyear::prelude::*;
 
 pub const BASE_SPEED: f32 = 200.0;
@@ -22,6 +21,7 @@ pub struct ColorComponent(pub Color);
 pub struct BikeMarker {
     pub client_id: ClientId,
     pub stopped: bool, // for testing
+    // TODO: these are unused right now!
     // The trail entity associated with the bike
     pub trail: Entity,
     // The zones entity associated with the bike
@@ -38,7 +38,7 @@ impl MapEntities for BikeMarker {
 impl Default for BikeMarker {
     fn default() -> Self {
         Self {
-            client_id: 0,
+            client_id: ClientId::Netcode(0),
             stopped: false,
             trail: Entity::PLACEHOLDER,
             zones: Entity::PLACEHOLDER,
@@ -58,14 +58,14 @@ pub struct BikeBundle {
 }
 
 impl BikeBundle {
-    pub fn new_at(client_id: ClientId, position: Vec2, color: Color, trail: Entity, zones: Entity) -> Self {
+    pub fn new_at(client_id: ClientId, position: Vec2, color: Color) -> Self {
         // TODO: spawn at a random position on the map
         Self {
             marker: BikeMarker {
                 client_id,
                 stopped: false,
-                trail,
-                zones,
+                trail: Entity::PLACEHOLDER,
+                zones: Entity::PLACEHOLDER,
             },
             position: Position(position),
             color: ColorComponent(color),

--- a/shared/src/player/zone.rs
+++ b/shared/src/player/zone.rs
@@ -1,10 +1,28 @@
 use bevy::prelude::*;
+use bevy::utils::HashSet;
 use bevy_prototype_lyon::prelude::*;
 use geo_clipper::Clipper;
 use geo_types::{Coord, LineString, MultiPolygon, Polygon};
+use lightyear::shared::replication::delta::Diffable;
 use serde::{Deserialize, Serialize};
+use crate::player::trail::Trail;
 
 const CLIPPER_SCALE: f64 = 1_000_000.0;
+
+#[derive(Bundle, Debug)]
+pub struct ZonesBundle {
+    pub zones: Zones,
+    pub name: Name,
+}
+
+impl Default for ZonesBundle {
+    fn default() -> Self {
+        Self {
+            zones: Zones::default(),
+            name: Name::from("Zones"),
+        }
+    }
+}
 
 pub struct ZonePlugin;
 
@@ -21,9 +39,47 @@ pub struct Zone {
     pub interiors: Vec<Vec<Vec2>>,
 }
 
+
+
+// TODO: maybe use a hashmap<barycenter, Zone> so that computing the diff is quicker?
 #[derive(Reflect, Component, Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct Zones {
     pub zones: Vec<Zone>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+pub struct ZonesDiff {
+    new_zones: Vec<Zone>,
+    removed_zones: Vec<Zone>,
+}
+
+impl Diffable for Zones {
+    type Delta = ZonesDiff;
+
+    fn base_value() -> Self {
+        Zones::default()
+    }
+
+    fn diff(&self, new: &Self) -> Self::Delta {
+        let mut diff = ZonesDiff::default();
+        for zone in self.zones.iter() {
+            if !new.zones.contains(zone) {
+                diff.removed_zones.push(zone.clone());
+            }
+        }
+        for zone in new.zones.iter() {
+            // TODO: use a hashset?
+            if !self.zones.contains(zone) {
+                diff.new_zones.push(zone.clone());
+            }
+        }
+        diff
+    }
+
+    fn apply_diff(&mut self, delta: &Self::Delta) {
+        self.zones.retain(|zone| !delta.removed_zones.contains(zone));
+        self.zones.extend(delta.new_zones.iter().cloned());
+    }
 }
 
 impl From<&Zones> for Path {


### PR DESCRIPTION
Delta compression for zones relies on some fragile assumptions:
- entities that have DeltaCompression must have only replicated component
- the order in which they are replicated matters! The Bike must be replicated before the Trail/Zones (so that the Parent component on the Trail/Zones are replicated correctly with entity mapping)

Currently we don't do any particular steps to enforce this, but it still seems to somewhat work